### PR TITLE
fix: rename apiKey to envKey and add comments for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
+## 0.0.7
+* Changed API key variable name from `apiKey` to `envKey`.
+* Added comments for better code clarity and maintainability.
+
 ## 0.0.6
 * Added API urls as parameters
+
 ## 0.0.5
 * Updated API url for Retack AI
+
 ## 0.0.4
 * Improved Readme.MD
+
 ## 0.0.3
 * Added repository url
+
 ## 0.0.2
 * Added supported platforms
+
 ## 0.0.1
-* First SDK version of Retack.Ai with functionality to post errors with user context.
+* First SDK version of Retack.AI with functionality to post errors with user context.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Here's a sample example for reference:
 
 ```dart
 
-final String falseenvKey = 'YOUR_ENV_KEY';
-final RetackClient client = RetackClient(RetackConfig(falseenvKey));
+final String falseEnvKey = 'YOUR_ENV_KEY';
+final RetackClient client = RetackClient(RetackConfig(falseEnvKey));
 
 try {
     throw const FormatException('Format Exception');

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Learn more: [Retack.AI](https://retack.ai)
 
 ## Getting started
 
-Start by creating an instance of `RetackClient` class by providing your `YOUR_API_KEY`.
+Start by creating an instance of `RetackClient` class by providing your `ENV_KEY`.
 
 ```dart
-final RetackConfig retackConfig = RetackConfig('YOUR_API_KEY');
+final RetackConfig retackConfig = RetackConfig('YOUR_ENV_KEY');
 final RetackClient retackClient = RetackClient(retackConfig);
 ```
 
@@ -23,8 +23,8 @@ Here's a sample example for reference:
 
 ```dart
 
-final String falseApiKey = 'YOUR_API_KEY';
-final RetackClient client = RetackClient(RetackConfig(falseApiKey));
+final String falseenvKey = 'YOUR_ENV_KEY';
+final RetackClient client = RetackClient(RetackConfig(falseenvKey));
 
 try {
     throw const FormatException('Format Exception');

--- a/lib/retack.dart
+++ b/lib/retack.dart
@@ -5,12 +5,12 @@ import 'package:http/http.dart' as http;
 
 /// Configuration for the RetackClient.
 class RetackConfig {
-  final String apiKey;
+  final String envKey;
   final String baseUrl;
   final String apiEndpoint;
 
   RetackConfig(
-    this.apiKey, {
+    this.envKey, {
     this.baseUrl = 'api.retack.ai',
     this.apiEndpoint = '/observe/error-log/',
   });
@@ -65,7 +65,7 @@ class RetackClient {
   }) async {
     final Map<String, String> headers = <String, String>{
       'Content-Type': 'application/json',
-      'ENV-KEY': _retackConfig.apiKey
+      'ENV-KEY': _retackConfig.envKey
     };
     var body = <String, dynamic>{
       "title": error,

--- a/lib/retack.dart
+++ b/lib/retack.dart
@@ -3,12 +3,24 @@ library retack;
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-/// Configuration for the RetackClient.
+/// Configuration class for setting up the RetackClient.
+///
+/// This holds the environment key [envKey], which is used for authentication
+/// and allows you to specify the [baseUrl] and [apiEndpoint] for the API.
 class RetackConfig {
+  // API authentication key to identify the environment.
   final String envKey;
+
+  // The base URL for the Retack AI API. Defaults to 'api.retack.ai'.
   final String baseUrl;
+
+  // The specific endpoint where error reports will be sent.
   final String apiEndpoint;
 
+  /// Constructs a new RetackConfig instance.
+  ///
+  /// [envKey] is required for authenticating requests to the API.
+  /// Optionally, you can override [baseUrl] and [apiEndpoint].
   RetackConfig(
     this.envKey, {
     this.baseUrl = 'api.retack.ai',
@@ -16,19 +28,29 @@ class RetackConfig {
   });
 }
 
-/// Additional context about the user.
+/// Class for providing additional context about the user in error reports.
+///
+/// Contains information such as [userName] and any other relevant
+/// metadata in the [extras] map.
 class UserContext {
-  // provide either unique userEmail or userName if available
+  // Optional: Username or email to identify the user.
   final String? userName;
-  // any extra meta-data about the user context
+
+  // Optional: Additional metadata about the user's context, such as session info.
   final Map<String, dynamic>? extras;
 
+  /// Constructs a new UserContext instance.
+  ///
+  /// Both [userName] and [extras] are optional and can provide more context
+  /// about the user when reporting an error.
   UserContext({
     this.userName,
     this.extras,
   });
 
-  // Method to convert UserContext to a JSON-encodable map
+  /// Converts the UserContext to a JSON-serializable map.
+  ///
+  /// This is used when sending the context information to the API.
   Map<String, dynamic> toJson() {
     return {
       'userName': userName,
@@ -37,51 +59,73 @@ class UserContext {
   }
 }
 
-/// A client for reporting errors to the Retack AI service.
+/// A client for interacting with the Retack AI error reporting service.
+///
+/// This class is responsible for sending error reports along with optional
+/// stack traces and user context to the Retack API.
 class RetackClient {
+  // The Retack configuration that contains API keys and endpoint details.
   final RetackConfig _retackConfig;
+
+  // A private static instance for implementing the Singleton pattern.
   static RetackClient? _instance;
 
-  /// Private constructor to prevent instantiation from outside.
+  /// Private constructor to prevent creating multiple instances.
+  ///
+  /// This is used internally by the factory constructor.
   RetackClient._(this._retackConfig);
 
-  /// Factory constructor to provide access to the singleton instance.
+  /// Factory constructor to provide a Singleton instance of RetackClient.
+  ///
+  /// Ensures that only one instance of the client exists throughout the app's
+  /// lifecycle. Takes [retackConfig] as the configuration for the client.
   factory RetackClient(RetackConfig retackConfig) {
+    // If _instance is null, create a new one, otherwise return the existing instance.
     _instance ??= RetackClient._(retackConfig);
     return _instance!;
   }
 
-  /// Reports an error to the Retack AI service.
+  /// Asynchronously reports an error to the Retack AI API.
   ///
-  /// [error] The error message.
-  /// [stackTrace] The stack trace of the error.
-  /// [userContext] Additional context about the user (optional).
+  /// [error] is the description of the error.
+  /// [stackTrace] contains the stack trace associated with the error.
+  /// Optionally, [userContext] can be provided to send more information
+  /// about the user affected by the error.
   ///
-  /// Returns `true` if the error was successfully reported, `false` otherwise.
+  /// Returns `true` if the error report was successfully sent, otherwise `false`.
   Future<bool> reportError(
     String error,
     dynamic stackTrace, {
     UserContext? userContext,
   }) async {
+    // Define the headers for the HTTP POST request, including the API key.
     final Map<String, String> headers = <String, String>{
-      'Content-Type': 'application/json',
-      'ENV-KEY': _retackConfig.envKey
-    };
-    var body = <String, dynamic>{
-      "title": error,
-      "stack_trace": stackTrace.toString(),
-      "user_context": userContext?.toJson(),
+      'Content-Type': 'application/json', // Data format is JSON
+      'ENV-KEY': _retackConfig.envKey // API key for authentication
     };
 
+    // Construct the body of the request with error, stack trace, and optional user context.
+    var body = <String, dynamic>{
+      "title": error, // The error message
+      "stack_trace":
+          stackTrace.toString(), // The stack trace converted to a string
+      "user_context": userContext?.toJson(), // User context, if provided
+    };
+
+    // Send an HTTP POST request to the Retack API using the provided configuration.
     final http.Response response = await http.post(
       Uri.https(_retackConfig.baseUrl, _retackConfig.apiEndpoint),
       headers: headers,
-      body: jsonEncode(body),
+      body: jsonEncode(body), // Encode the body to JSON format
     );
+
+    // If the response status is not 200 (OK), log the error to the console.
     if (response.statusCode != 200) {
       print('Unable to report error to Retack AI.');
       print(response.body);
     }
+
+    // Return true if the response status is 200 (OK), otherwise false.
     return response.statusCode == 200;
   }
 }

--- a/test/retack_test.dart
+++ b/test/retack_test.dart
@@ -1,21 +1,30 @@
 import 'package:test/test.dart';
-
 import 'package:retack/retack.dart';
 
 void main() {
-  test('Test Retack AI fails with Invalid Key', () async {
-    final String falseenvKey = 'CMskbtq_xDA46XAkAzQe1JEY12';
-    final RetackClient client = RetackClient(RetackConfig(falseenvKey));
+  // Grouping the test case(s) under a descriptive label for better organization
+  group('RetackClient Error Reporting', () {
+    test('Test Retack AI fails with Invalid Key', () async {
+      // Arrange: Set up the RetackClient with a fake/invalid environment key.
+      final String falseEnvKey =
+          'CMskbtq_xDA46XAkAzQe1JEY12'; // This key is intentionally invalid
+      final RetackClient client = RetackClient(RetackConfig(falseEnvKey));
 
-    try {
-      throw const FormatException('Format Exception');
-    } catch (_, __) {
-      final bool resp = await client.reportError(
-        _.toString(),
-        __,
-        userContext: UserContext(userName: 'user@retack.io'),
-      );
-      expect(resp, false);
-    }
+      try {
+        // Act: Triggering an error (in this case, a FormatException) to simulate an error scenario
+        throw const FormatException('Format Exception');
+      } catch (error, stackTrace) {
+        // Act: Attempting to report the error to Retack with the invalid key
+        final bool resp = await client.reportError(
+          error.toString(), // Convert the error to a string
+          stackTrace, // Capture the stack trace of the error
+          userContext: UserContext(
+              userName: 'user@retack.io'), // Providing a mock user context
+        );
+
+        // Assert: Since the environment key is invalid, we expect the error report to fail (i.e., resp should be false)
+        expect(resp, false);
+      }
+    });
   });
 }

--- a/test/retack_test.dart
+++ b/test/retack_test.dart
@@ -4,8 +4,8 @@ import 'package:retack/retack.dart';
 
 void main() {
   test('Test Retack AI fails with Invalid Key', () async {
-    final String falseApiKey = 'CMskbtq_xDA46XAkAzQe1JEY12';
-    final RetackClient client = RetackClient(RetackConfig(falseApiKey));
+    final String falseenvKey = 'CMskbtq_xDA46XAkAzQe1JEY12';
+    final RetackClient client = RetackClient(RetackConfig(falseenvKey));
 
     try {
       throw const FormatException('Format Exception');


### PR DESCRIPTION
- Refactored README for better clarity and updated usage examples.
- Updated changelog to reflect changes made in version 0.0.7.
- Renamed `apiKey` to `envKey` across the documentation to match the latest code changes.
